### PR TITLE
Fix for iOS crash when calling hide() after the indicator has already…

### DIFF
--- a/src/ios/ProgressIndicator.m
+++ b/src/ios/ProgressIndicator.m
@@ -405,6 +405,7 @@
 		return;
 	}
 	[self.progressIndicator hide:YES];
+	self.progressIndicator = nil;
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@""];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }


### PR DESCRIPTION
… been hidden


By nilling out the `progressIndicator` instance variable in the hide method, multiple calls to `hide()` after a progress indicator has already hidden will prevent this plugin from crashing on iOS.