### PR TITLE
Updated Android package name and path on plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,9 +37,9 @@
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="ProgressIndicator">
-                <param name="android-package" value="org.apache.cordova.plugin.ProgressIndicator"/>
+                <param name="android-package" value="org.apache.cordova.progressindicator.ProgressIndicator"/>
             </feature>
         </config-file>
-        <source-file src="src/android/ProgressIndicator.java" target-dir="src/org/apache/cordova/plugin"/>
+        <source-file src="src/android/ProgressIndicator.java" target-dir="src/org/apache/cordova/progressindicator"/>
     </platform>
 </plugin>


### PR DESCRIPTION
Package name was updated on source file but not on plugin.xml. Therefore, ClassNotFoundException is being thrown when the plugin is used in Android.

I also updated the source file path to match the package name. 

This request is related to bug #25.