### PR TITLE
Fix iOS crash when hiding indicator

### DIFF
--- a/src/ios/ProgressIndicator.m
+++ b/src/ios/ProgressIndicator.m
@@ -405,6 +405,7 @@
 		return;
 	}
 	[self.progressIndicator hide:YES];
+    self.progressIndicator = nil;
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@""];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }


### PR DESCRIPTION
$cordovaProgress.hide() crashes app to crash without this fix.