### PR TITLE
Added support for Cordova Android 7 (patch)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@
 
     <!-- Android -->
     <platform name="android">
-        <config-file target="res/xml/config.xml" parent="/*">
+        <config-file target="app/src/main/res/xml/config.xml" parent="/*">
             <feature name="ProgressIndicator">
                 <param name="android-package" value="org.apache.cordova.progressindicator.ProgressIndicator"/>
             </feature>


### PR DESCRIPTION
Cordova Android 7.0.0 changed the file structure which breaks this plugin. This PR fixes that.

https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html